### PR TITLE
Spike/add legend with custom colors and ranges

### DIFF
--- a/examples/demo-app/src/constants/default-settings.js
+++ b/examples/demo-app/src/constants/default-settings.js
@@ -23,7 +23,7 @@ and segments both use queryRunner */
 import keyMirror from 'keymirror';
 
 export const ASSETS_URL = 'https://d1a3f4spazzrp4.cloudfront.net/kepler.gl/';
-export const DATA_URL = 'https://raw.githubusercontent.com/uber-web/kepler.gl-data/master/';
+export const DATA_URL = 'https://stcitiespublic.blob.core.windows.net/assets/kepler/';
 export const MAP_URI = 'demo/map?mapUrl=';
 /*
  * If you want to add more samples, feel free to edit the json file on github kepler.gl data repo

--- a/src/components/common/color-legend.js
+++ b/src/components/common/color-legend.js
@@ -88,7 +88,7 @@ const getQuantLegends = (scale, labelFormat) => {
       labels: []
     };
   }
-
+  console.log('🚀 ~ file: color-legend.js ~ line 93 ~ scale.domain()', scale.domain());
   const labels = scale.range().map(d => {
     const invert = scale.invertExtent(d);
     return `${labelFormat(invert[0])} to ${labelFormat(invert[1])}`;
@@ -146,10 +146,16 @@ export default class ColorLegend extends Component {
         }
 
         const scaleFunction = SCALE_FUNC[scaleType];
+        console.log('🚀 ~ file: color-legend.js ~ line 150 ~ scaleType', scaleType);
+        console.log(
+          '🚀 ~ file: color-legend.js ~ line 150 ~ SCALE_FUNC[scaleType]',
+          SCALE_FUNC[scaleType]
+        );
         // color scale can only be quantize, quantile or ordinal
         // @ts-ignore fix d3 scale
+        // TODO: domain should come from the config
         const scale = scaleFunction()
-          .domain(domain)
+          .domain([5, 10, 15, 25, 35, 40, 50, 60, 70])
           .range(range.colors);
 
         if (scaleType === SCALE_TYPES.ordinal) {
@@ -157,7 +163,6 @@ export default class ColorLegend extends Component {
         }
 
         const formatLabel = labelFormat || getQuantLabelFormat(scale.domain(), fieldType);
-
         return getQuantLegends(scale, formatLabel);
       }
       return empty;

--- a/src/components/common/color-legend.js
+++ b/src/components/common/color-legend.js
@@ -153,9 +153,8 @@ export default class ColorLegend extends Component {
         );
         // color scale can only be quantize, quantile or ordinal
         // @ts-ignore fix d3 scale
-        // TODO: domain should come from the config
         const scale = scaleFunction()
-          .domain([5, 10, 15, 25, 35, 40, 50, 60, 70])
+          .domain(range.ranges || domain)
           .range(range.colors);
 
         if (scaleType === SCALE_TYPES.ordinal) {

--- a/src/constants/custom-color-ranges.js
+++ b/src/constants/custom-color-ranges.js
@@ -28,6 +28,7 @@ export const SEQ = 'sequential';
 export const SIN = 'singlehue';
 export const QUA = 'qualitative';
 export const DIV = 'diverging';
+export const STD = 'standard';
 
 export const DataVizColors = {
   aqua: '#12939A',
@@ -547,5 +548,22 @@ export const VizColorPalette = [
   ...divergingColors,
   ...sequantialColors,
   ...qualitativeColors,
-  ...customPalette
+  ...customPalette,
+  {
+    name: 'BelAQI',
+    type: STD,
+    category: 'BelAQI',
+    colors: [
+      '#006837',
+      '#1a9850',
+      '#66bd63',
+      '#a6d96a',
+      '#d9ef8b',
+      '#fee08b',
+      '#fdae61',
+      '#f46d43',
+      '#d73027',
+      '#a50026'
+    ]
+  }
 ];

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -306,7 +306,10 @@ export const SCALE_TYPES = keyMirror({
   log: null,
 
   // ordinal domain to linear range
-  point: null
+  point: null,
+
+  // belaqi
+  belaqi: null
 });
 
 export const SCALE_FUNC = {
@@ -316,7 +319,9 @@ export const SCALE_FUNC = {
   [SCALE_TYPES.ordinal]: scaleOrdinal,
   [SCALE_TYPES.sqrt]: scaleSqrt,
   [SCALE_TYPES.log]: scaleLog,
-  [SCALE_TYPES.point]: scalePoint
+  [SCALE_TYPES.point]: scalePoint,
+  // belaqi
+  [SCALE_TYPES.belaqi]: scaleQuantize
 };
 
 export const ALL_FIELD_TYPES = keyMirror({
@@ -449,7 +454,7 @@ export const AGGREGATION_TYPES = {
 };
 
 export const linearFieldScaleFunctions = {
-  [CHANNEL_SCALES.color]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile],
+  [CHANNEL_SCALES.color]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile, SCALE_TYPES.belaqi],
   [CHANNEL_SCALES.radius]: [SCALE_TYPES.sqrt],
   [CHANNEL_SCALES.size]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log]
 };

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -28,7 +28,8 @@ import {
   scaleOrdinal,
   scaleSqrt,
   scaleLog,
-  scalePoint
+  scalePoint,
+  scaleThreshold
 } from 'd3-scale';
 import {
   Layers,
@@ -321,7 +322,7 @@ export const SCALE_FUNC = {
   [SCALE_TYPES.log]: scaleLog,
   [SCALE_TYPES.point]: scalePoint,
   // belaqi
-  [SCALE_TYPES.belaqi]: scaleQuantize
+  [SCALE_TYPES.belaqi]: scaleThreshold
 };
 
 export const ALL_FIELD_TYPES = keyMirror({

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -426,6 +426,7 @@ class Layer {
     if (!object) {
       return null;
     }
+
     // By default, each entry of layerData should have an index of a row in the original data container.
     // Each layer can implement its own getHoverData method
     return dataContainer.row(object.index);
@@ -719,7 +720,7 @@ class Layer {
   }
 
   getColorScale(colorScale, colorDomain, colorRange) {
-    console.log('🚀 ~ file: base-layer.js ~ line 722 ~ -------------- getColorScale', {
+    console.log('🚀 ~ file: base-layer.js ~ line 722 ~ --- getColorScale', {
       colorScale,
       colorDomain,
       colorRange
@@ -739,14 +740,19 @@ class Layer {
     }
     if (colorScale === 'belaqi') {
       console.log('BELAQI', {colorScale, colorDomain, colorRange});
-      // return getBelaqi()
+      // TODO: domain should come from the config
+      // const scaleFn = scaleThreshold()
+      //   .domain([5, 10, 15, 25, 35, 40, 50, 60, 70])
+      //   .range(colorRange.colors);
+      return this.getVisChannelScale(
+        'belaqi',
+        [5, 10, 15, 25, 35, 40, 50, 60, 70],
+        colorRange.colors.map(hexToRgb)
+      );
+      // return scale;
     }
     return this.getVisChannelScale(colorScale, colorDomain, colorRange.colors.map(hexToRgb));
   }
-
-  // getBelaqi() {
-  //   return
-  // }
 
   /**
    * Mapping from visual channels to deck.gl accesors
@@ -756,7 +762,6 @@ class Layer {
    * @return {Object} attributeAccessors - deck.gl layer attribute accessors
    */
   getAttributeAccessors({dataAccessor = defaultDataAccessor, dataContainer}) {
-    console.log('🚀 ~ file: base-layer.js ~ line 752 ~ getAttributeAccessors');
     const attributeAccessors = {};
 
     Object.keys(this.visualChannels).forEach(channel => {
@@ -778,8 +783,6 @@ class Layer {
       if (shouldGetScale) {
         const args = [this.config[scale], this.config[domain], this.config.visConfig[range]];
         const isFixed = fixed && this.config.visConfig[fixed];
-        console.log(channelScaleType === CHANNEL_SCALES.color ? 'yes' : 'no');
-        console.log('🚀 ~ file: base-layer.js ~ line 776 ~ CHANNEL_SCALES', CHANNEL_SCALES);
         let scaleFunction;
         if (channelScaleType === CHANNEL_SCALES.color) {
           scaleFunction = this.getColorScale(...args);
@@ -820,7 +823,6 @@ class Layer {
     const scaleFunc = SCALE_FUNC[fixed ? 'linear' : scale]()
       .domain(domain)
       .range(fixed ? domain : range);
-    console.log('🚀 ~ file: base-layer.js ~ line 809 ~ scaleFunc', scaleFunc);
     return scaleFunc;
   }
 
@@ -883,6 +885,9 @@ class Layer {
       attributeValue = scale(new Date(value));
     } else {
       attributeValue = scale(value);
+      // console.log('🚀 ~ file: base-layer.js ~ line 888 ~ attributeValue', {
+      //   [value]: attributeValue
+      // });
     }
 
     if (!notNullorUndefined(attributeValue)) {

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -857,11 +857,6 @@ class Layer {
     nullValue = NO_VALUE_COLOR,
     getValue = defaultGetFieldValue
   ) {
-    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ getValue', getValue);
-    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ nullValue', nullValue);
-    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ field', field);
-    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ data', data);
-    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ scale', scale);
     const {type} = field;
     const value = getValue(field, data);
 
@@ -876,9 +871,6 @@ class Layer {
       attributeValue = scale(new Date(value));
     } else {
       attributeValue = scale(value);
-      // console.log('🚀 ~ file: base-layer.js ~ line 888 ~ attributeValue', {
-      //   [value]: attributeValue
-      // });
     }
 
     if (!notNullorUndefined(attributeValue)) {

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -740,16 +740,7 @@ class Layer {
     }
     if (colorScale === 'belaqi') {
       console.log('BELAQI', {colorScale, colorDomain, colorRange});
-      // TODO: domain should come from the config
-      // const scaleFn = scaleThreshold()
-      //   .domain([5, 10, 15, 25, 35, 40, 50, 60, 70])
-      //   .range(colorRange.colors);
-      return this.getVisChannelScale(
-        'belaqi',
-        [5, 10, 15, 25, 35, 40, 50, 60, 70],
-        colorRange.colors.map(hexToRgb)
-      );
-      // return scale;
+      return this.getVisChannelScale('belaqi', colorRange.ranges, colorRange.colors.map(hexToRgb));
     }
     return this.getVisChannelScale(colorScale, colorDomain, colorRange.colors.map(hexToRgb));
   }

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -426,7 +426,6 @@ class Layer {
     if (!object) {
       return null;
     }
-
     // By default, each entry of layerData should have an index of a row in the original data container.
     // Each layer can implement its own getHoverData method
     return dataContainer.row(object.index);
@@ -650,6 +649,7 @@ class Layer {
     const {colorUI, visConfig} = this.config;
     const {steps, reversed} = colorUI[prop].colorRangeConfig;
     const colorRange = visConfig[prop];
+
     // find based on step or reversed
     let update;
     if (newConfig.colorRangeConfig.hasOwnProperty('steps')) {
@@ -719,6 +719,11 @@ class Layer {
   }
 
   getColorScale(colorScale, colorDomain, colorRange) {
+    console.log('🚀 ~ file: base-layer.js ~ line 722 ~ -------------- getColorScale', {
+      colorScale,
+      colorDomain,
+      colorRange
+    });
     if (Array.isArray(colorRange.colorMap)) {
       const cMap = new Map();
       colorRange.colorMap.forEach(([k, v]) => {
@@ -732,9 +737,16 @@ class Layer {
         .unknown(cMap.get(UNKNOWN_COLOR_KEY) || NO_VALUE_COLOR);
       return scale;
     }
-
+    if (colorScale === 'belaqi') {
+      console.log('BELAQI', {colorScale, colorDomain, colorRange});
+      // return getBelaqi()
+    }
     return this.getVisChannelScale(colorScale, colorDomain, colorRange.colors.map(hexToRgb));
   }
+
+  // getBelaqi() {
+  //   return
+  // }
 
   /**
    * Mapping from visual channels to deck.gl accesors
@@ -744,6 +756,7 @@ class Layer {
    * @return {Object} attributeAccessors - deck.gl layer attribute accessors
    */
   getAttributeAccessors({dataAccessor = defaultDataAccessor, dataContainer}) {
+    console.log('🚀 ~ file: base-layer.js ~ line 752 ~ getAttributeAccessors');
     const attributeAccessors = {};
 
     Object.keys(this.visualChannels).forEach(channel => {
@@ -765,11 +778,14 @@ class Layer {
       if (shouldGetScale) {
         const args = [this.config[scale], this.config[domain], this.config.visConfig[range]];
         const isFixed = fixed && this.config.visConfig[fixed];
-
-        const scaleFunction =
-          channelScaleType === CHANNEL_SCALES.color
-            ? this.getColorScale(...args)
-            : this.getVisChannelScale(...args, isFixed);
+        console.log(channelScaleType === CHANNEL_SCALES.color ? 'yes' : 'no');
+        console.log('🚀 ~ file: base-layer.js ~ line 776 ~ CHANNEL_SCALES', CHANNEL_SCALES);
+        let scaleFunction;
+        if (channelScaleType === CHANNEL_SCALES.color) {
+          scaleFunction = this.getColorScale(...args);
+        } else {
+          scaleFunction = this.getVisChannelScale(...args, isFixed);
+        }
 
         attributeAccessors[accessor] = d =>
           this.getEncodedChannelValue(
@@ -789,15 +805,23 @@ class Layer {
         Console.warn(`Failed to provide accessor function for ${accessor || channel}`);
       }
     });
-
     return attributeAccessors;
   }
 
   getVisChannelScale(scale, domain, range, fixed) {
+    console.log('🚀 ~ file: base-layer.js ~ line 802 ~ getVisChannelScale', {
+      scale,
+      domain,
+      range,
+      fixed
+    });
+
     // @ts-ignore d3-scale type
-    return SCALE_FUNC[fixed ? 'linear' : scale]()
+    const scaleFunc = SCALE_FUNC[fixed ? 'linear' : scale]()
       .domain(domain)
       .range(fixed ? domain : range);
+    console.log('🚀 ~ file: base-layer.js ~ line 809 ~ scaleFunc', scaleFunc);
+    return scaleFunc;
   }
 
   /**
@@ -840,6 +864,11 @@ class Layer {
     nullValue = NO_VALUE_COLOR,
     getValue = defaultGetFieldValue
   ) {
+    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ getValue', getValue);
+    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ nullValue', nullValue);
+    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ field', field);
+    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ data', data);
+    // console.log('🚀 ~ file: base-layer.js ~ line 862 ~ scale', scale);
     const {type} = field;
     const value = getValue(field, data);
 


### PR DESCRIPTION
## Changes
- add custom legend with BelAQI colors and ranges
- BelAQI colors come from the adjusted config -> https://stcitiespublic.blob.core.windows.net/assets/kepler/samples.json -> https://stcitiespublic.blob.core.windows.net/assets/kepler/unemployment_config.json

## Good to know
If you encounter a bug, please state under this PR

## How to test
- execute `nvm use 12` to use Node 12
- export you mapbox toke before starting your app `export MapboxAccessToken=***`
- only tested with unemployment sample data -> http://localhost:8080/demo/county_unemployment

## Images
![MicrosoftTeams-image (7)](https://user-images.githubusercontent.com/22441648/186111752-46946c3f-76e9-4f41-a2f5-29cbe7816c52.png)

