### PR TITLE
PREC-129:  added ranges to graphVisConfigs

### DIFF
--- a/src/layers/graph-layer/graph-layer.js
+++ b/src/layers/graph-layer/graph-layer.js
@@ -61,7 +61,11 @@ const brushingExtension = new BrushingExtension();
 export const graphVisConfigs = {
   opacity: 'opacity',
   strokeColor: 'strokeColor',
-  colorRange: 'colorRange'
+  colorRange: 'colorRange',
+  strokeColorRange: 'strokeColorRange',
+  sizeRange: 'strokeWidthRange',
+  radiusRange: 'radiusRange',
+  heightRange: 'elevationRange'
 };
 
 export default class GraphLayer extends Layer {


### PR DESCRIPTION
Added the default ranges as a fallback to the graphviz of the graph layer.
This should fix the error thrown when searching for the label in the legend.

## How to reproduce

1. Uncomment line 391 in `app.js`
1. Start project as normal using `yarn start`
1. Open the legend
1. App should no longer crash

