### PR TITLE
[PREC-132] Graph only works for example graph

### DIFF
--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -151,10 +151,10 @@ class App extends Component {
     // this._loadPointData();
     // this._loadGeojsonData();
     // this._loadTripGeoJson();
-    // this._loadGraphLayer();
+    this._loadGraphLayer();
     // this._loadIconData();
     // this._loadH3HexagonData();
-    this._loadH3HData();
+    // this._loadH3HData();
     // this._loadS2Data();
     // this._loadScenegraphLayer();
     // this._loadBelAQI();

--- a/examples/demo-app/src/data/sample-json-graph.js
+++ b/examples/demo-app/src/data/sample-json-graph.js
@@ -5,94 +5,54 @@ export default {
     nodes: [
       {
         id: '1',
-        label: 'Power plant',
+        label: 'Power Plant (ENGIE Electrabel)',
         metadata: {
-          'is-a': ['room'],
-          gis: [],
-          x: 4.434661720198483,
-          y: 51.20594386351399,
-          'water-level-for-flooding-in-cm': [23],
-          icon: 'https://cdne-cities-assets.azureedge.net/precinct/marker.png',
-          event: 'flood',
-          time: 0,
-          oldState: 1,
-          newState: 5,
-          description: '"flood" at "Room 1". The state changed from "operational" to "outage".',
-          newStateName: 'outage',
-          oldStateName: 'operational'
+          x: 4.258873845576631,
+          y: 51.32482250095482,
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/power-plant.png'
         }
       },
       {
         id: '2',
-        label: 'Water pump',
+        label: 'Water pump (Aquafin Antwerp-South)',
         metadata: {
-          'is-a': ['room'],
-          x: 4.413684631292414,
-          y: 51.230266736445024,
-          icon: 'https://stcitiespublic.blob.core.windows.net/assets/precinct/marker.png',
-          event: 'flood',
-          time: 1,
-          originator: 1,
-          oldState: 1,
-          newState: 5,
-          description:
-            '"flood" at "Room 2". fire spread via "Room 1". The state changed from "operational" to "outage".',
-          newStateName: 'outage',
-          oldStateName: 'operational'
+          x: 4.36955582033667,
+          y: 51.19878530037734,
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/water-pump.png'
         }
       },
       {
         id: '3',
-        label: 'Kennedy Tunnel',
+        label: 'Kennedytunnel',
         metadata: {
-          'is-a': ['room'],
           x: 4.371651627317661,
           y: 51.205651742412726,
-          icon: 'https://stcitiespublic.blob.core.windows.net/assets/precinct/marker.png',
-          event: 'flood',
-          time: 2,
-          originator: 2,
-          oldState: 1,
-          newState: 5,
-          description:
-            '"flood" at "Room 3". fire spread via "Room 2". The state changed from "operational" to "majorly affected".',
-          newStateName: 'outage',
-          oldStateName: 'operational'
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/tunnel.png'
         }
       },
       {
         id: '4',
-        label: 'Hospital',
+        label: 'Hospital (GZA Hospitals campus Sint-Vincentius)',
         metadata: {
-          'is-a': ['room'],
           x: 4.422055727014319,
           y: 51.21352710975356,
-          icon: 'https://stcitiespublic.blob.core.windows.net/assets/precinct/marker.png',
-          event: 'fire',
-          time: 3,
-          originator: 1,
-          oldState: 1,
-          newState: 5,
-          description:
-            '"flood" at "Room 4". fire spread via "Room 3". The state changed from "operational" to "majorly affected".',
-          newStateName: 'outage',
-          oldStateName: 'operational'
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/hospital.png'
         }
       }
     ],
     edges: [
       {
-        label: 'Power plant - Water pump',
+        label: 'Power Plant (ENGIE Electrabel) - Water pump (Aquafin Antwerp-South)',
         source: '1',
         target: '2'
       },
       {
-        label: 'Water pump - Kennedy Tunnel',
+        label: 'Water pump (Aquafin Antwerp-South) - Kennedytunnel',
         source: '2',
         target: '3'
       },
       {
-        label: 'Power plant - Hospital',
+        label: 'Power Plant (ENGIE Electrabel) - Hospital (GZA Hospitals campus Sint-Vincentius)',
         source: '1',
         target: '4'
       }

--- a/src/layers/graph-layer/graph-layer.js
+++ b/src/layers/graph-layer/graph-layer.js
@@ -22,11 +22,8 @@ import {BrushingExtension} from '@deck.gl/extensions';
 import {IconLayer, LineLayer} from '@deck.gl/layers';
 
 import Layer from '../base-layer';
-import {hexToRgb} from 'utils/color-utils';
 import {findDefaultColorField} from 'utils/dataset-utils';
 import GraphLayerIcon from './graph-layer-icon';
-import {DEFAULT_LAYER_COLOR} from 'constants/default-settings';
-import {LAYER_VIS_CONFIGS} from 'layers/layer-factory';
 
 export const iconPosAccessor = ({icon}) => dc => d => {
   if (!icon) {
@@ -42,7 +39,7 @@ export const iconPosAccessor = ({icon}) => dc => d => {
   };
 };
 
-export const edgePosAccessor = ({coordinates, type}) => dc => d => {
+export const graphPosAccessor = ({coordinates, type}) => dc => d => {
   if (!type || !coordinates) {
     return null;
   }
@@ -74,7 +71,7 @@ export default class GraphLayer extends Layer {
 
     this.registerVisConfig(graphVisConfigs);
     this.getPositionAccessor = dataContainer => {
-      return edgePosAccessor(this.config.columns)(dataContainer);
+      return graphPosAccessor(this.config.columns)(dataContainer);
     };
     this.getIconAccessor = dataContainer => {
       return iconPosAccessor(this.config.columns)(dataContainer);

--- a/src/layers/graph-layer/graph-layer.js
+++ b/src/layers/graph-layer/graph-layer.js
@@ -165,10 +165,11 @@ export default class GraphLayer extends Layer {
 
   calculateDataAttribute({fields, filteredIndex, dataContainer}, getPosition) {
     const data = [];
+    const typeIdx = fields.find(field => field.name === 'type').fieldIdx;
 
     for (let i = 0; i < filteredIndex.length; i++) {
       const index = filteredIndex[i];
-      const type = dataContainer.valueAt(index, 16);
+      const type = dataContainer.valueAt(index, typeIdx);
       const pos = getPosition({index, type});
 
       // if doesn't have point lat or lng, do not add the point

--- a/src/processors/data-processor.js
+++ b/src/processors/data-processor.js
@@ -543,35 +543,40 @@ export function processGraph(rawData) {
 
   rawData.graph.nodes.forEach(node => {
     const {
-      metadata: {x, y, ...metadata},
-      ...rest
+      id,
+      label,
+      metadata: {x, y, icon, ...metadata}
     } = node;
 
     const mappedNode = {
-      ...rest,
       ...metadata,
+      id,
+      label,
       coordinates: [x, y],
-      from: null,
-      to: null,
-      type: 'node'
+      icon,
+      type: 'node',
+      from: null, // To align edges and nodes in the dataframe
+      to: null // To align edges and nodes in the dataframe
     };
 
-    nodeMap[rest.id] = mappedNode;
+    nodeMap[id] = mappedNode;
     graphData.push(mappedNode);
   });
 
   rawData.graph.edges.forEach(edge => {
-    const {source, target, ...rest} = edge;
+    const {id, source, target, label, ...rest} = edge;
 
     const from = nodeMap[source];
     const to = nodeMap[target];
 
     graphData.push({
       ...rest,
+      id,
+      label,
       coordinates: [...from.coordinates, ...to.coordinates],
+      type: 'edge',
       from: from.label,
-      to: to.label,
-      type: 'edge'
+      to: to.label
     });
   });
 


### PR DESCRIPTION
The graph layer only worked for the example graph. The reason was a hardcoded index `16` when selecting the type. This is now not hardcoded anymore and depends on the fieldIdx of the field with name `type`