### PR TITLE
[PREC-77] Graph layer colors

### DIFF
--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -310,7 +310,23 @@ class App extends Component {
                   type: 'graph',
                   config: {
                     dataId: 'graph-layer-1',
-                    isVisible: true
+                    isVisible: true,
+                    visConfig: {
+                      colorRange: {
+                        name: 'custom',
+                        type: 'standard',
+                        category: 'BelAQI',
+                        ranges: [1, 2, 3, 4, 5],
+                        colors: ['#4dff01', '#fdff00', '#f9bb02', '#f66600', '#f50b00'],
+                        reversed: false
+                      },
+                      strokeColor: [11, 255, 255],
+                      opacity: 0.8
+                    }
+                  },
+                  visualChannels: {
+                    colorField: {name: 'newState', type: 'integer'},
+                    colorScale: 'treshold'
                   }
                 }
               ]

--- a/examples/demo-app/src/data/sample-json-graph.js
+++ b/examples/demo-app/src/data/sample-json-graph.js
@@ -9,7 +9,8 @@ export default {
         metadata: {
           x: 4.258873845576631,
           y: 51.32482250095482,
-          icon: 'https://cdne-cities-assets.azureedge.net/precinct/power-plant.png'
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/power-plant.png',
+          newState: 1
         }
       },
       {
@@ -18,7 +19,8 @@ export default {
         metadata: {
           x: 4.36955582033667,
           y: 51.19878530037734,
-          icon: 'https://cdne-cities-assets.azureedge.net/precinct/water-pump.png'
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/water-pump.png',
+          newState: 2
         }
       },
       {
@@ -27,7 +29,8 @@ export default {
         metadata: {
           x: 4.371651627317661,
           y: 51.205651742412726,
-          icon: 'https://cdne-cities-assets.azureedge.net/precinct/tunnel.png'
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/tunnel.png',
+          newState: 4
         }
       },
       {
@@ -36,7 +39,8 @@ export default {
         metadata: {
           x: 4.422055727014319,
           y: 51.21352710975356,
-          icon: 'https://cdne-cities-assets.azureedge.net/precinct/hospital.png'
+          icon: 'https://cdne-cities-assets.azureedge.net/precinct/hospital.png',
+          newState: 5
         }
       }
     ],

--- a/src/components/side-panel/layer-panel/layer-configurator.js
+++ b/src/components/side-panel/layer-panel/layer-configurator.js
@@ -127,6 +127,64 @@ export default function LayerConfiguratorFactory(
       return this._renderScatterplotLayerConfig(props);
     }
 
+    _renderGraphLayerConfig({
+      layer,
+      visConfiguratorProps,
+      layerChannelConfigProps,
+      layerConfiguratorProps
+    }) {
+      return (
+        <StyledLayerVisualConfigurator>
+          {/* Fill Color */}
+          <LayerConfigGroup
+            {...(layer.visConfigSettings.filled || {label: 'layer.color'})}
+            {...visConfiguratorProps}
+            property={undefined}
+            label="Icon color"
+            collapsible
+          >
+            {layer.config.colorField ? (
+              <LayerColorRangeSelector {...visConfiguratorProps} />
+            ) : (
+              <LayerColorSelector {...layerConfiguratorProps} />
+            )}
+            <ConfigGroupCollapsibleContent>
+              <ChannelByValueSelector
+                channel={layer.visualChannels.color}
+                {...layerChannelConfigProps}
+              />
+            </ConfigGroupCollapsibleContent>
+          </LayerConfigGroup>
+
+          {/* Outline color */}
+          <LayerConfigGroup
+            {...layer.visConfigSettings.outline}
+            {...visConfiguratorProps}
+            property={undefined}
+            label="Line color"
+            collapsible
+          >
+            {layer.config.strokeColorField ? (
+              <LayerColorRangeSelector {...visConfiguratorProps} property="strokeColorRange" />
+            ) : (
+              <LayerColorSelector
+                {...visConfiguratorProps}
+                selectedColor={layer.config.visConfig.strokeColor}
+                property="strokeColor"
+              />
+            )}
+            <ConfigGroupCollapsibleContent>
+              <ChannelByValueSelector
+                channel={layer.visualChannels.strokeColor}
+                {...layerChannelConfigProps}
+              />
+            </ConfigGroupCollapsibleContent>
+          </LayerConfigGroup>
+          <VisConfigSlider {...layer.visConfigSettings.opacity} {...visConfiguratorProps} />
+        </StyledLayerVisualConfigurator>
+      );
+    }
+
     _renderScatterplotLayerConfig({
       layer,
       visConfiguratorProps,


### PR DESCRIPTION
Support was added to the graph layer to configure colors. This is also reflected in the kepler UI. An example has been created in the demo app.js to test it out.

(Note: In the screenshot i selected a single color for the edges, you can also have this as a range but it is to showcase that we can mix and match.)
![Screenshot 2022-10-19 at 10 29 29](https://user-images.githubusercontent.com/22447514/196638875-c016d02b-ecc2-4765-a61f-74fed6c4b36a.png)

Reflected in the UI:
![Screenshot 2022-10-19 at 10 30 59](https://user-images.githubusercontent.com/22447514/196639156-04ed23cf-0735-44e8-b456-6a8772c54f96.png)
