### PR TITLE
[POC] Animated trip layers not depending on timeline filter

### DIFF
--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -109,7 +109,7 @@ export const Attribution = () => (
 
 MapContainerFactory.deps = [MapPopoverFactory, MapControlFactory, EditorFactory];
 export default function MapContainerFactory(MapPopover, MapControl, Editor) {
-  let myUnsafePreviousTime = Date.now();
+  let myUnsafePreviousTime = performance.now();
   class MapContainer extends Component {
     static propTypes = {
       // required
@@ -180,7 +180,7 @@ export default function MapContainerFactory(MapPopover, MapControl, Editor) {
     }
 
     _myUnsafeTimeout = () => {
-      const time = Date.now();
+      const time = performance.now();
       if (myUnsafePreviousTime < time - 1000 / 60) {
         myUnsafePreviousTime = time;
         this.setState(({myUnsafeTimestamp, ...prev}) => ({

--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -109,7 +109,8 @@ export const Attribution = () => (
 
 MapContainerFactory.deps = [MapPopoverFactory, MapControlFactory, EditorFactory];
 export default function MapContainerFactory(MapPopover, MapControl, Editor) {
-  let myUnsafePreviousTime = performance.now();
+  let myUnsafeStart;
+  let myUnsafePreviousTime;
   class MapContainer extends Component {
     static propTypes = {
       // required
@@ -179,18 +180,18 @@ export default function MapContainerFactory(MapPopover, MapControl, Editor) {
       unobserveDimensions(this._ref.current);
     }
 
-    _myUnsafeTimeout = () => {
-      const time = performance.now();
-      if (myUnsafePreviousTime < time - 1000 / 60) {
-        myUnsafePreviousTime = time;
+    _myUnsafeTimeout = timestamp => {
+      if (myUnsafePreviousTime === undefined) {
+        myUnsafePreviousTime = timestamp;
+      }
+      if (myUnsafePreviousTime < timestamp - 1000 / 24) {
+        myUnsafePreviousTime = timestamp;
         this.setState(({myUnsafeTimestamp, ...prev}) => ({
           ...prev,
           myUnsafeTimestamp: myUnsafeTimestamp + 1
         }));
       }
-      requestAnimationFrame(() => {
-        this._myUnsafeTimeout();
-      });
+      requestAnimationFrame(this._myUnsafeTimeout);
     };
 
     _handleResize = dimensions => {

--- a/src/layers/graph-layer/graph-layer.js
+++ b/src/layers/graph-layer/graph-layer.js
@@ -20,6 +20,7 @@
 
 import {BrushingExtension} from '@deck.gl/extensions';
 import {IconLayer, LineLayer} from '@deck.gl/layers';
+import {TripsLayer} from '@deck.gl/geo-layers';
 
 import Layer from '../base-layer';
 import {findDefaultColorField} from 'utils/dataset-utils';
@@ -223,7 +224,8 @@ export default class GraphLayer extends Layer {
       // eslint-disable-next-line no-unused-vars
       data: {data: not_in_use, nodes, edges, ...data},
       gpuFilter,
-      interactionConfig
+      interactionConfig,
+      myUnsafeTimestamp
     } = opts;
 
     const updateTriggers = {
@@ -237,25 +239,40 @@ export default class GraphLayer extends Layer {
     const extensions = [...defaultLayerProps.extensions, brushingExtension];
 
     return [
-      new LineLayer({
-        ...defaultLayerProps,
+      // new LineLayer({
+      //   ...defaultLayerProps,
+      //   id: `edges-${defaultLayerProps.id}`,
+      //   idx: defaultLayerProps.idx,
+      //   ...brushingProps,
+      //   ...data,
+      //   data: edges,
+      //   parameters: {
+      //     // circles will be flat on the map when the altitude column is not used
+      //     depthTest: this.config.columns.altitude?.fieldIdx > -1
+      //   },
+      //   lineWidthUnits: 'pixels',
+      //   updateTriggers,
+      //   extensions,
+
+      //   getColor: [63, 152, 189],
+      //   getWidth: 8,
+      //   getSourcePosition: d => d.coordinates.from,
+      //   getTargetPosition: d => d.coordinates.to
+      // }),
+      new TripsLayer({
         id: `edges-${defaultLayerProps.id}`,
         idx: defaultLayerProps.idx,
-        ...brushingProps,
-        ...data,
         data: edges,
-        parameters: {
-          // circles will be flat on the map when the altitude column is not used
-          depthTest: this.config.columns.altitude?.fieldIdx > -1
-        },
-        lineWidthUnits: 'pixels',
-        updateTriggers,
-        extensions,
-
-        getColor: [63, 152, 189],
-        getWidth: 8,
-        getSourcePosition: d => d.coordinates.from,
-        getTargetPosition: d => d.coordinates.to
+        getPath: d => [d.coordinates.from, d.coordinates.to],
+        // deduct start timestamp from each data point to avoid overflow
+        getTimestamps: d => [0, 200],
+        getColor: [253, 128, 93],
+        opacity: 0.8,
+        rounded: true,
+        fadeTrail: true,
+        trailLength: 120,
+        currentTime: myUnsafeTimestamp % 200,
+        widthMinPixels: 5
       }),
       new IconLayer({
         ...defaultLayerProps,

--- a/src/layers/graph-layer/graph-layer.js
+++ b/src/layers/graph-layer/graph-layer.js
@@ -35,7 +35,8 @@ export const iconPosAccessor = ({icon}) => dc => d => {
     url: dc.valueAt(d.index, icon.fieldIdx),
     width: 64,
     height: 64,
-    anchorY: 64
+    anchorY: 64,
+    mask: true
   };
 };
 
@@ -272,7 +273,8 @@ export default class GraphLayer extends Layer {
         extensions,
 
         // IconLayer stuff
-        getSize: 32
+        getSize: 32,
+        getColor: [252, 3, 232]
       })
     ];
   }

--- a/src/utils/layer-utils.js
+++ b/src/utils/layer-utils.js
@@ -114,7 +114,7 @@ export function getLayerHoverProp({
   return null;
 }
 
-export function renderDeckGlLayer(props, layerCallbacks, idx) {
+export function renderDeckGlLayer(props, layerCallbacks, idx, myUnsafeTimestamp) {
   const {
     datasets,
     layers,
@@ -141,7 +141,8 @@ export function renderDeckGlLayer(props, layerCallbacks, idx) {
     mapState,
     animationConfig,
     objectHovered,
-    visible
+    visible,
+    myUnsafeTimestamp
   });
 }
 


### PR DESCRIPTION
So i made a poc on how we could tackle this. Take a look at the code if you want to. The latest version updates the trips at 60FPS (which we can still reduce)

`Gif is 10fps`
![Oct-19-2022 10-34-25](https://user-images.githubusercontent.com/22447514/196639864-5d0f59bb-4888-49ce-9695-0e1bfbfde79e.gif)
