### PR TITLE
[CF-1266]: geojson polygon filtering

### DIFF
--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -859,7 +859,8 @@ export const EDITOR_AVAILABLE_LAYERS = [
   LAYER_TYPES.hexagon,
   LAYER_TYPES.arc,
   LAYER_TYPES.line,
-  LAYER_TYPES.hexagonId
+  LAYER_TYPES.hexagonId,
+  LAYER_TYPES.geojson
 ];
 // GPU Filtering
 /**

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -404,19 +404,20 @@ export const getPolygonFilterFunctor = (layer, filter, dataContainer) => {
 };
 
 /**
- * Returns an array of Points (array of coordinates) of a given geojson's position.
+ * Returns the array of Points (array of coordinates) of a given GeoJson position.
  * @param position
  * @returns ([number, number] || [number, number, number])[]
  */
 function getGeoJsonPoints(position) {
+  const coordinates = position?.coordinates ?? [];
   switch (position.type) {
     case 'Point':
-      return [position.coordinates];
+      return [coordinates];
     case 'LineString':
-      return position.coordinates;
+      return coordinates;
     case 'Polygon':
       // exterior line ring
-      return position.coordinates[0];
+      return coordinates[0];
     default:
       // unsupported type
       return [];

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -445,7 +445,6 @@ function getGeoJsonPoints(position) {
       return getGeoJsonPoints(position.geometry);
     default:
       Console.log(`Unsupported geojson type ${position?.type}`);
-      // Console.error(`Unsupported geojson type`);
       return [];
   }
 }

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -394,14 +394,26 @@ export const getPolygonFilterFunctor = (layer, filter, dataContainer) => {
     case LAYER_TYPES.geojson:
       return data => {
         const pos = getPosition(data);
-        return getGeoJsonPoints(pos).every(
-          point => point.every(Number.isFinite) && isInPolygon(point, filter.value)
-        );
+        return isGeoJsonPositionInPolygon(pos, filter.value);
       };
     default:
       return () => true;
   }
 };
+
+/**
+ * Returns whether a GeoJson position is inside a given Polygon.
+ * A position is considered to be inside a polygon if all of its points are
+ * located inside said Polygon.
+ * @param position
+ * @param polygon
+ * @returns boolean
+ */
+export function isGeoJsonPositionInPolygon(position, polygon) {
+  return getGeoJsonPoints(position).every(
+    point => point.every(Number.isFinite) && isInPolygon(point, polygon)
+  );
+}
 
 /**
  * Returns the array of Points (array of coordinates) of a given GeoJson position.

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -20,7 +20,7 @@
 
 import {ascending, extent, histogram as d3Histogram, ticks} from 'd3-array';
 import keyMirror from 'keymirror';
-import {console as Console} from 'global/console';
+import {console as Console} from 'global/window';
 import get from 'lodash.get';
 import isEqual from 'lodash.isequal';
 
@@ -421,8 +421,17 @@ export function isGeoJsonPositionInPolygon(position, polygon) {
  * @returns ([number, number] || [number, number, number])[]
  */
 function getGeoJsonPoints(position) {
+  if (typeof position === 'string') {
+    try {
+      position = JSON.parse(position);
+    } catch (e) {
+      Console.error(`Could not parse position: ${position}`);
+      return [];
+    }
+  }
+
   const coordinates = position?.coordinates ?? [];
-  switch (position.type) {
+  switch (position?.type) {
     case 'Point':
       return [coordinates];
     case 'LineString':
@@ -435,7 +444,8 @@ function getGeoJsonPoints(position) {
     case 'Feature':
       return getGeoJsonPoints(position.geometry);
     default:
-      Console.error(`Unsupported geojson type`);
+      Console.log(`Unsupported geojson type ${position?.type}`);
+      // Console.error(`Unsupported geojson type`);
       return [];
   }
 }

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -394,7 +394,7 @@ export const getPolygonFilterFunctor = (layer, filter, dataContainer) => {
     case LAYER_TYPES.geojson:
       return data => {
         const pos = getPosition(data);
-        return isGeoJsonPositionInPolygon(pos, filter.value);
+        return pos && isGeoJsonPositionInPolygon(pos, filter.value);
       };
     default:
       return () => true;
@@ -430,8 +430,12 @@ function getGeoJsonPoints(position) {
     case 'Polygon':
       // exterior line ring
       return coordinates[0];
+    case 'MultiPolygon':
+      return coordinates.flatMap(c => c[0]);
+    case 'Feature':
+      return getGeoJsonPoints(position.geometry);
     default:
-      // unsupported type
+      Console.error(`Unsupported geojson type`);
       return [];
   }
 }

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -391,10 +391,37 @@ export const getPolygonFilterFunctor = (layer, filter, dataContainer) => {
         const pos = getCentroid({id});
         return pos.every(Number.isFinite) && isInPolygon(pos, filter.value);
       };
+    case LAYER_TYPES.geojson:
+      return data => {
+        const pos = getPosition(data);
+        return getGeoJsonPoints(pos).every(
+          point => point.every(Number.isFinite) && isInPolygon(point, filter.value)
+        );
+      };
     default:
       return () => true;
   }
 };
+
+/**
+ * Returns an array of Points (array of coordinates) of a given geojson's position.
+ * @param position
+ * @returns ([number, number] || [number, number, number])[]
+ */
+function getGeoJsonPoints(position) {
+  switch (position.type) {
+    case 'Point':
+      return [position.coordinates];
+    case 'LineString':
+      return position.coordinates;
+    case 'Polygon':
+      // exterior line ring
+      return position.coordinates[0];
+    default:
+      // unsupported type
+      return [];
+  }
+}
 
 /**
  * @param field dataset Field

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -412,12 +412,36 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${data[0][0]} - ${data[0][0]} should not be inside the range`
   );
 
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: pointPosition
+      },
+      polygonFilter.value
+    ),
+    false,
+    `(feature) ${pointPosition.coordinates} should not be in range`
+  );
+
   pointPosition.coordinates = [data[0][1], data[0][0]];
 
   t.equal(
     isGeoJsonPositionInPolygon(pointPosition, polygonFilter.value),
     true,
     `${data[0][1]} - ${data[0][1]} should be inside the range`
+  );
+
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: pointPosition
+      },
+      polygonFilter.value
+    ),
+    true,
+    `(feature) ${pointPosition.coordinates} should be in range`
   );
 
   const lineStringPosition = {
@@ -431,6 +455,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${lineStringPosition.coordinates} should not be in range`
   );
 
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: lineStringPosition
+      },
+      polygonFilter.value
+    ),
+    false,
+    `(feature) ${lineStringPosition.coordinates} should not be in range`
+  );
+
   lineStringPosition.coordinates = [
     [data[0][1], data[0][0]],
     [data[0][1], data[2][0]]
@@ -440,6 +476,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     isGeoJsonPositionInPolygon(lineStringPosition, polygonFilter.value),
     true,
     `${lineStringPosition.coordinates} should be in range`
+  );
+
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: lineStringPosition
+      },
+      polygonFilter.value
+    ),
+    true,
+    `(feature) ${lineStringPosition.coordinates} should be in range`
   );
 
   const polygonPosition = {
@@ -459,6 +507,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${polygonPosition.coordinates} should be in range`
   );
 
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: polygonPosition
+      },
+      polygonFilter.value
+    ),
+    true,
+    `(feature) ${polygonPosition.coordinates} should be in range`
+  );
+
   polygonPosition.coordinates = [
     [data[0].slice(0, 2), data[0].slice(0, 2), data[0].slice(0, 2), data[0].slice(2)]
   ];
@@ -467,6 +527,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     isGeoJsonPositionInPolygon(polygonPosition, polygonFilter.value),
     false,
     `${polygonPosition.coordinates} should not be in range`
+  );
+
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: polygonPosition
+      },
+      polygonFilter.value
+    ),
+    false,
+    `(feature) ${polygonPosition.coordinates} should not be in range`
   );
 
   polygonPosition.coordinates = [
@@ -483,6 +555,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     isGeoJsonPositionInPolygon(polygonPosition, polygonFilter.value),
     true,
     `${polygonPosition.coordinates} should be in range`
+  );
+
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: polygonPosition
+      },
+      polygonFilter.value
+    ),
+    true,
+    `(feature) ${polygonPosition.coordinates} should be in range`
   );
 
   const multiPolygonPosition = {

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -682,6 +682,56 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon (MultiPolygon)', t => {
   t.end();
 });
 
+test('filterUtils -> Polygon isGeoJsonPositionInPolygon (Position as String)', t => {
+  const {layers, data} = mockPolygonData;
+  const polygonFilter = generatePolygonFilter(layers, mockPolygonFeature);
+
+  const multiPolygonPosition = {
+    type: 'MultiPolygon',
+    coordinates: [
+      [
+        [
+          [data[0][1], data[0][0]],
+          [data[2][1], data[2][0]],
+          [data[0][1], data[0][0]]
+        ]
+      ],
+      [
+        [
+          [data[2][1], data[2][0]],
+          [data[0][1], data[0][0]],
+          [data[2][1], data[2][0]]
+        ]
+      ]
+    ]
+  };
+
+  t.equal(
+    isGeoJsonPositionInPolygon(JSON.stringify(multiPolygonPosition), polygonFilter.value),
+    true,
+    `${multiPolygonPosition.coordinates} should be in range`
+  );
+
+  multiPolygonPosition.coordinates[0] = [
+    [
+      [data[1][1], data[2][0]],
+      [data[0][1], data[0][0]],
+      [data[2][1], data[2][0]]
+    ]
+  ];
+
+  t.equal(
+    isGeoJsonPositionInPolygon(JSON.stringify(multiPolygonPosition), polygonFilter.value),
+    false,
+    `${multiPolygonPosition.coordinates} should not be in range`
+  );
+
+  const malformedString = 'something that is not json';
+  t.equal(isGeoJsonPositionInPolygon(malformedString, polygonFilter.value), true);
+
+  t.end();
+});
+
 /* eslint-enable max-statements */
 
 test('filterUtils -> diffFilters', t => {

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -459,7 +459,9 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${polygonPosition.coordinates} should be in range`
   );
 
-  polygonPosition.coordinates = [[data[0].slice(0, 2), data[0].slice(2)]];
+  polygonPosition.coordinates = [
+    [data[0].slice(0, 2), data[0].slice(0, 2), data[0].slice(0, 2), data[0].slice(2)]
+  ];
 
   t.equal(
     isGeoJsonPositionInPolygon(polygonPosition, polygonFilter.value),
@@ -481,6 +483,60 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     isGeoJsonPositionInPolygon(polygonPosition, polygonFilter.value),
     true,
     `${polygonPosition.coordinates} should be in range`
+  );
+
+  const multiPolygonPosition = {
+    type: 'MultiPolygon',
+    coordinates: [
+      [
+        [
+          [data[0][1], data[0][0]],
+          [data[2][1], data[2][0]],
+          [data[0][1], data[0][0]]
+        ]
+      ],
+      [
+        [
+          [data[2][1], data[2][0]],
+          [data[0][1], data[0][0]],
+          [data[2][1], data[2][0]]
+        ]
+      ]
+    ]
+  };
+
+  t.equal(
+    isGeoJsonPositionInPolygon(multiPolygonPosition, polygonFilter.value),
+    true,
+    `${multiPolygonPosition.coordinates} should be in range`
+  );
+
+  multiPolygonPosition.coordinates[0] = [
+    [
+      [data[1][1], data[2][0]],
+      [data[0][1], data[0][0]],
+      [data[2][1], data[2][0]]
+    ]
+  ];
+
+  t.equal(
+    isGeoJsonPositionInPolygon(multiPolygonPosition, polygonFilter.value),
+    false,
+    `${multiPolygonPosition.coordinates} should not be in range`
+  );
+
+  multiPolygonPosition.coordinates[1] = [
+    [
+      [data[0][1], data[0][0]],
+      [data[1][1], data[2][0]],
+      [data[0][1], data[0][0]]
+    ]
+  ];
+
+  t.equal(
+    isGeoJsonPositionInPolygon(multiPolygonPosition, polygonFilter.value),
+    false,
+    `${multiPolygonPosition.coordinates} should not be in range`
   );
 
   t.end();

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -397,7 +397,7 @@ test('filterUtils -> Polygon getFilterFunction ', t => {
   t.end();
 });
 
-test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
+test('filterUtils -> Polygon isGeoJsonPositionInPolygon (Point)', t => {
   const {layers, data} = mockPolygonData;
   const polygonFilter = generatePolygonFilter(layers, mockPolygonFeature);
 
@@ -444,6 +444,13 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `(feature) ${pointPosition.coordinates} should be in range`
   );
 
+  t.end();
+});
+
+test('filterUtils -> Polygon isGeoJsonPositionInPolygon (LineString)', t => {
+  const {layers, data} = mockPolygonData;
+  const polygonFilter = generatePolygonFilter(layers, mockPolygonFeature);
+
   const lineStringPosition = {
     type: 'LineString',
     coordinates: [data[0].slice(0, 2), data[0].slice(2)]
@@ -489,6 +496,13 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     true,
     `(feature) ${lineStringPosition.coordinates} should be in range`
   );
+
+  t.end();
+});
+
+test('filterUtils -> Polygon isGeoJsonPositionInPolygon (Polygon)', t => {
+  const {layers, data} = mockPolygonData;
+  const polygonFilter = generatePolygonFilter(layers, mockPolygonFeature);
 
   const polygonPosition = {
     type: 'Polygon',
@@ -569,6 +583,12 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `(feature) ${polygonPosition.coordinates} should be in range`
   );
 
+  t.end();
+});
+
+test('filterUtils -> Polygon isGeoJsonPositionInPolygon (MultiPolygon)', t => {
+  const {layers, data} = mockPolygonData;
+  const polygonFilter = generatePolygonFilter(layers, mockPolygonFeature);
   const multiPolygonPosition = {
     type: 'MultiPolygon',
     coordinates: [

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -420,6 +420,28 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${data[0][1]} - ${data[0][1]} should be inside the range`
   );
 
+  const lineStringPosition = {
+    type: 'LineString',
+    coordinates: [data[0].slice(0, 2), data[0].slice(2)]
+  };
+
+  t.equal(
+    isGeoJsonPositionInPolygon(lineStringPosition, polygonFilter.value),
+    false,
+    `${lineStringPosition.coordinates} should not be in range`
+  );
+
+  lineStringPosition.coordinates = [
+    [data[0][1], data[0][0]],
+    [data[0][1], data[2][0]]
+  ];
+
+  t.equal(
+    isGeoJsonPositionInPolygon(lineStringPosition, polygonFilter.value),
+    true,
+    `${lineStringPosition.coordinates} should be in range`
+  );
+
   t.end();
 });
 

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -511,6 +511,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${multiPolygonPosition.coordinates} should be in range`
   );
 
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: multiPolygonPosition
+      },
+      polygonFilter.value
+    ),
+    true,
+    `(feature)${multiPolygonPosition.coordinates} should be in range`
+  );
+
   multiPolygonPosition.coordinates[0] = [
     [
       [data[1][1], data[2][0]],
@@ -525,6 +537,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${multiPolygonPosition.coordinates} should not be in range`
   );
 
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: multiPolygonPosition
+      },
+      polygonFilter.value
+    ),
+    false,
+    `(feature) ${multiPolygonPosition.coordinates} should not be in range`
+  );
+
   multiPolygonPosition.coordinates[1] = [
     [
       [data[0][1], data[0][0]],
@@ -537,6 +561,18 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     isGeoJsonPositionInPolygon(multiPolygonPosition, polygonFilter.value),
     false,
     `${multiPolygonPosition.coordinates} should not be in range`
+  );
+
+  t.equal(
+    isGeoJsonPositionInPolygon(
+      {
+        type: 'Feature',
+        geometry: multiPolygonPosition
+      },
+      polygonFilter.value
+    ),
+    false,
+    `(feature) ${multiPolygonPosition.coordinates} should not be in range`
   );
 
   t.end();

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -31,7 +31,8 @@ import {
   isInPolygon,
   diffFilters,
   getHistogram,
-  getTimestampFieldDomain
+  getTimestampFieldDomain,
+  isGeoJsonPositionInPolygon
 } from 'utils/filter-utils';
 
 import {getDatasetFieldIndexForFilter} from 'utils/gpu-filter-utils';
@@ -391,6 +392,32 @@ test('filterUtils -> Polygon getFilterFunction ', t => {
     filterFunction(data[0], 0),
     true,
     `${data[0][0]} - ${data[0][1]} should be inside the range`
+  );
+
+  t.end();
+});
+
+test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
+  const {layers, data} = mockPolygonData;
+  const polygonFilter = generatePolygonFilter(layers, mockPolygonFeature);
+
+  const pointPosition = {
+    type: 'Point',
+    coordinates: [data[0][0], data[0][0]]
+  };
+
+  t.equal(
+    isGeoJsonPositionInPolygon(pointPosition, polygonFilter.value),
+    false,
+    `${data[0][0]} - ${data[0][0]} should not be inside the range`
+  );
+
+  pointPosition.coordinates = [data[0][1], data[0][0]];
+
+  t.equal(
+    isGeoJsonPositionInPolygon(pointPosition, polygonFilter.value),
+    true,
+    `${data[0][1]} - ${data[0][1]} should be inside the range`
   );
 
   t.end();

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -442,6 +442,47 @@ test('filterUtils -> Polygon isGeoJsonPositionInPolygon', t => {
     `${lineStringPosition.coordinates} should be in range`
   );
 
+  const polygonPosition = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [data[0][1], data[0][0]],
+        [data[0][1], data[2][0]],
+        [data[0][1], data[0][0]]
+      ]
+    ]
+  };
+
+  t.equal(
+    isGeoJsonPositionInPolygon(polygonPosition, polygonFilter.value),
+    true,
+    `${polygonPosition.coordinates} should be in range`
+  );
+
+  polygonPosition.coordinates = [[data[0].slice(0, 2), data[0].slice(2)]];
+
+  t.equal(
+    isGeoJsonPositionInPolygon(polygonPosition, polygonFilter.value),
+    false,
+    `${polygonPosition.coordinates} should not be in range`
+  );
+
+  polygonPosition.coordinates = [
+    // only the exterior Line Ring should matter (first array)
+    [
+      [data[0][1], data[0][0]],
+      [data[0][1], data[2][0]],
+      [data[0][1], data[0][0]]
+    ],
+    [data[0].slice(0, 2), data[0].slice(2)]
+  ];
+
+  t.equal(
+    isGeoJsonPositionInPolygon(polygonPosition, polygonFilter.value),
+    true,
+    `${polygonPosition.coordinates} should be in range`
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
In CityFlows we have a requirement to be able to filter the datasets based on what the user selects on the screen. Currently, KeplerGL supports filtering datasets using Polygons drawn to the screen. However, GeoJson data types are not currently supported.

The goal of this PR is to add support to filtering GeoJson data using Polygons (at least to the feature types we need at the moment).

[CityFlows-geojson-filtering.webm](https://user-images.githubusercontent.com/16376552/201674366-d774533f-4b8e-43bd-944e-4d6bb66a1d22.webm)

