### PR TITLE
fix: use texture2D delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imec-int/kepler.gl",
   "author": "imec <admin@imec-apt.be>",
-  "version": "2.5.5-16",
+  "version": "2.5.5-17",
   "description": "kepler.gl is a webgl based application to visualize large scale location data in the browser",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/deckgl-layers/float-bitmap-layer/float-bitmap-layer.js
+++ b/src/deckgl-layers/float-bitmap-layer/float-bitmap-layer.js
@@ -95,11 +95,12 @@ class FloatBitmapLayer extends BitmapLayer {
 
   finalizeState() {
     super.finalizeState(this.context);
-    const {gl} = this.context;
     const {image} = this.state;
 
     // Cleanup the texture when the layer is removed
-    image.delete();
+    if (image) {
+      image.delete();
+    }
   }
 }
 

--- a/src/deckgl-layers/float-bitmap-layer/float-bitmap-layer.js
+++ b/src/deckgl-layers/float-bitmap-layer/float-bitmap-layer.js
@@ -99,7 +99,7 @@ class FloatBitmapLayer extends BitmapLayer {
     const {image} = this.state;
 
     // Cleanup the texture when the layer is removed
-    gl.deleteTexture(image);
+    image.delete();
   }
 }
 


### PR DESCRIPTION
gl.deleteTexture is a WebGL method and is not usable with luma.gl.
Instead the Texture2D.delete() is used as demonstrated in deckgl bitmaplayer: https://github.com/visgl/deck.gl/blob/8.2-release/modules/layers/src/bitmap-layer/bitmap-layer.js#L122